### PR TITLE
Removed space in arguments, changed assistant intent's condition

### DIFF
--- a/lib/google_assistant.rb
+++ b/lib/google_assistant.rb
@@ -115,7 +115,7 @@ class GoogleAssistant
   end
 
   def build_expected_intent(intent)
-    if intent.nil? || intent == ""
+    if intent.nil? || intent.empty?
       return handle_error("Invalid intent")
     end
 

--- a/lib/google_assistant/argument.rb
+++ b/lib/google_assistant/argument.rb
@@ -4,7 +4,7 @@ class GoogleAssistant
 
     def initialize(opts)
       @name = opts["name"]
-      @raw_text = opts ["raw_text"]
+      @raw_text = opts["raw_text"]
       @text_value = opts["text_value"]
     end
   end


### PR DESCRIPTION
Found your gem in some twitter daily news. Went through code to find how it was implemented and found some strange space between hash variable and key. Was a bit surprised that it's working, but created a PR so you can notice that place.

Shouldn't it have the same check as line 118 ?
https://github.com/armilam/google-assistant-ruby/blob/master/lib/google_assistant.rb#L126