### PR TITLE
Improve build input prompt

### DIFF
--- a/lib/google_assistant/dialog_state.rb
+++ b/lib/google_assistant/dialog_state.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "json"
+
 class GoogleAssistant
   class DialogState
     DEFAULT_STATE = { "state" => nil, "data" => {} }.freeze


### PR DESCRIPTION
Resolves #14 

This changes the API of `#ask` and removes `build_input_prompt` as a public API. This should simplify the interface for users.